### PR TITLE
Improve port and process management

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+language: haskell
+
+matrix:
+  include:
+    - os: linux
+    - os: osx
+
+install:
+    - cabal update
+
+script:
+  - cd test-sandbox
+  - cabal install --only-dependencies --enable-tests
+  - "cabal configure --enable-tests --ghc-options=-Werror && cabal build && cabal test "
+  - "cabal sdist && cabal install dist/test-sandbox-*.tar.gz"
+  - cd ../test-sandbox-hunit
+  - cabal install --only-dependencies --enable-tests
+  - "cabal configure --enable-tests --ghc-options=-Werror && cabal build && cabal test "
+  - "cabal sdist && cabal install dist/test-sandbox-*.tar.gz"
+  - cd ../test-sandbox-quickcheck
+  - cabal install --only-dependencies --enable-tests
+  - "cabal configure --enable-tests --ghc-options=-Werror && cabal build && cabal test "
+  - "cabal sdist && cabal install dist/test-sandbox-quickcheck-*.tar.gz"
+  - cd ../test-framework-sandbox
+  - cabal install --only-dependencies --enable-tests
+  - "cabal configure --enable-tests --ghc-options=-Werror && cabal build && cabal test "
+  - "cabal sdist && cabal install dist/test-framework-sandbox-*.tar.gz"

--- a/test-framework-sandbox/test-framework-sandbox.cabal
+++ b/test-framework-sandbox/test-framework-sandbox.cabal
@@ -1,5 +1,5 @@
 Name:           test-framework-sandbox
-Version:        0.0.2.3
+Version:        0.0.2.4
 Cabal-Version:  >= 1.14
 Category:       Testing
 Synopsis:       test-sandbox support for the test-framework package
@@ -29,16 +29,18 @@ Source-Repository head
 Source-Repository this
     Type:       git
     Location:   https://github.com/gree/haskell-test-sandbox
-    Tag:        test-framework-sandbox_0.0.2.3
+    Tag:        test-framework-sandbox_0.0.2.4
 
 Library
     Exposed-modules:    Test.Framework.Providers.Sandbox
                         Test.Framework.Providers.Sandbox.Internals
 
     Build-Depends:      base >=4 && <5, ansi-terminal, lifted-base, mtl,
-                        temporary, test-framework >=0.8.0.3, test-sandbox >=0.0.1.5 && <0.0.2,
+                        temporary, test-framework >=0.8.0.3, test-sandbox >=0.0.1.9 && <0.0.2,
                         transformers
 
     Hs-source-dirs:     src
 
     Default-Language:   Haskell2010
+
+    ghc-options:       -Wall

--- a/test-sandbox-hunit/test-sandbox-hunit.cabal
+++ b/test-sandbox-hunit/test-sandbox-hunit.cabal
@@ -1,5 +1,5 @@
 Name:           test-sandbox-hunit
-Version:        0.0.1.5
+Version:        0.0.1.6
 Cabal-Version:  >= 1.14
 Category:       Testing
 Synopsis:       HUnit convenience functions for use with test-sandbox
@@ -18,7 +18,7 @@ Source-Repository head
 Source-Repository this
     Type:       git
     Location:   https://github.com/gree/haskell-test-sandbox
-    Tag:        test-sandbox-hunit_0.0.1.5
+    Tag:        test-sandbox-hunit_0.0.1.6
 
 Library
     Exposed-modules:    Test.Sandbox.HUnit
@@ -28,3 +28,5 @@ Library
     Hs-source-dirs:     src
 
     Default-Language:   Haskell2010
+
+    ghc-options:       -Wall

--- a/test-sandbox-quickcheck/test-sandbox-quickcheck.cabal
+++ b/test-sandbox-quickcheck/test-sandbox-quickcheck.cabal
@@ -1,5 +1,5 @@
 Name:           test-sandbox-quickcheck
-Version:        0.0.1.5
+Version:        0.0.1.6
 Cabal-Version:  >= 1.14
 Category:       Testing
 Synopsis:       QuickCheck convenience functions for use with test-sandbox
@@ -18,14 +18,16 @@ Source-Repository head
 Source-Repository this
     Type:       git
     Location:   https://github.com/gree/haskell-test-sandbox
-    Tag:        test-sandbox-quickcheck_0.0.1.5
+    Tag:        test-sandbox-quickcheck_0.0.1.6
 
 Library
     Exposed-modules:    Test.Sandbox.QuickCheck
 
     Build-Depends:      base >=4 && <5, mtl, random, transformers,
-                        test-sandbox >=0.0.1.5 && <0.0.2, QuickCheck >=2.1
+                        test-sandbox >=0.0.1.9 && <0.0.2, QuickCheck >=2.7
 
     Hs-source-dirs:     src
 
     Default-Language:   Haskell2010
+
+    ghc-options:       -Wall

--- a/test-sandbox/src/Test/Sandbox/Process.hs
+++ b/test-sandbox/src/Test/Sandbox/Process.hs
@@ -1,0 +1,61 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE CPP #-}
+
+module Test.Sandbox.Process where
+import System.Posix.Types
+import System.Posix.Signals
+import Text.Regex.Posix
+import Data.Maybe
+import Control.Exception
+import Control.Monad
+import System.Directory
+import qualified Data.Set as S
+
+#if defined(__MACOSX__) ||  defined(__WIN32__)
+#else
+data ProcessInfo = ProcessInfo {
+   piPid  :: ProcessID
+,  piStat :: String
+,  piPpid :: ProcessID
+,  piPgid :: ProcessGroupID
+} deriving (Show,Eq,Read)
+
+getProcessInfo :: String -> Maybe ProcessInfo
+getProcessInfo v =
+  if v =~ pattern
+    then
+      case v =~ pattern of
+        [[_str,pid,stat,ppid,pgid]] -> Just $ ProcessInfo (read pid) stat (read ppid) (read pgid)
+        _ -> Nothing
+    else
+      Nothing
+  where
+    pattern = "^([0-9]+) \\([^\\)]*\\) ([RSDZTW]) ([0-9]+) ([0-9]+) [0-9]+ .*"
+
+getProcessInfos :: IO [ProcessInfo]
+getProcessInfos = do
+  dirs <- getDirectoryContents "/proc"
+  let processes = filter ( =~ "[0-9]+") dirs
+  stats <- forM processes $ \ps -> do {
+    file <- (readFile $ "/proc/" ++ ps ++ "/stat") ;
+    file `seq` return $ getProcessInfo file
+    } `catch` (\(_ :: SomeException) -> return Nothing)
+  return $ catMaybes stats
+
+getProcessGroupIDs :: IO [ProcessGroupID]
+getProcessGroupIDs = do
+  infos <- getProcessInfos
+  return $ map (\info -> piPgid info) infos
+
+getProcessIDs :: [ProcessGroupID] -> IO [ProcessID]
+getProcessIDs pgids = do
+  infos <- getProcessInfos
+  let pgids' = S.fromList $ pgids
+  return $ map (\info -> piPid info) $ filter (\info -> S.member (piPgid info) pgids') infos
+#endif
+
+cleanUpProcessGroupIDs :: [ProcessGroupID] -> IO ()
+cleanUpProcessGroupIDs pgids = do
+  forM_ pgids $ \pgid -> do
+    signalProcessGroup sigKILL pgid `catch`  (\(_::SomeException) -> return ())
+

--- a/test-sandbox/test-sandbox.cabal
+++ b/test-sandbox/test-sandbox.cabal
@@ -1,5 +1,5 @@
 Name:           test-sandbox
-Version:        0.0.1.8
+Version:        0.0.1.9
 Cabal-Version:  >= 1.14
 Category:       Testing
 Synopsis:       Sandbox for system tests
@@ -25,18 +25,42 @@ Source-Repository head
 Source-Repository this
     Type:       git
     Location:   https://github.com/gree/haskell-test-sandbox
-    Tag:        test-sandbox_0.0.1.8
+    Tag:        test-sandbox_0.0.1.9
 
 Library
     Exposed-modules:    Test.Sandbox
                         Test.Sandbox.Internals
+                        Test.Sandbox.Process
 
     Build-Depends:      base >=4 && <5, bytestring, cereal, containers,
                         data-default, directory, filepath, lifted-base,
                         monad-control, monad-loops, mtl, network, process,
-                        random, random-shuffle, temporary, transformers,
-                        transformers-base, unix
+                        random, random-shuffle, temporary, transformers >= 0.4,
+                        transformers-base, unix, regex-posix
 
     Hs-source-dirs:     src
+    Default-Language:   Haskell2010
+    ghc-options:       -Wall
 
+test-suite test
+    type:              exitcode-stdio-1.0
+    main-is:           test.hs
+    hs-source-dirs:    test,dist/build/autogen
+    ghc-options:       -Wall
+
+    build-depends: base
+                 , test-sandbox
+                 , hspec
+                 , template-haskell
+                 , heredoc
+                 , hastache
+                 , text
+                 , containers
+                 , unix
+                 , mtl
+                 , transformers
+                 , regex-posix
+                 , directory
+                 , process
+                 , QuickCheck
     Default-Language:   Haskell2010

--- a/test-sandbox/test/test.hs
+++ b/test-sandbox/test/test.hs
@@ -1,0 +1,183 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE CPP #-}
+import Test.Hspec
+import Test.QuickCheck
+import Test.QuickCheck.Monadic (assert,monadicIO)
+import Test.Sandbox
+import qualified Test.Sandbox.Internals as I
+import Text.Heredoc
+import qualified Text.Hastache as H
+import qualified Text.Hastache.Context as H
+import qualified Data.Text.Lazy as TL
+import qualified Data.Text as T
+import qualified Data.Map as M
+import System.Posix.Files
+import Data.IORef
+import Data.Char
+import Control.Concurrent
+
+a2b :: String -> String
+a2b [] = []
+a2b ('a':xs) = 'b':xs
+a2b (x:xs) = x:a2b xs
+
+a2btest :: I.SandboxStateRef -> [Char] -> Property
+a2btest ref str' = a2btest' ref $ filter isAlphaNum str'
+
+a2btest' :: I.SandboxStateRef -> [Char] -> Property
+a2btest' ref str' =
+  monadicIO $ do
+    v <- liftIO $ runSandbox' ref $ interactWith "sed_regex" (str' ++ "\n") 1
+    assert $ v == ((a2b str') ++ "\n")
+
+main :: IO ()
+main = withSandbox $ \gref -> do
+  hspec $ do
+    describe "Basic Test" $ do
+      it "interactive Test by sandbox" $ do
+        sandbox "hogehoge" $ do
+          start =<< register "sed_regex" "sed" [ "-u", "s/a/b/" ] def { psCapture = Just CaptureStdout }
+          v <- interactWith "sed_regex" "a\n" 1
+          liftIO $ v `shouldBe` "b\n"
+      it "interactive Test by withSandbox" $ do
+        withSandbox $ \ref -> do
+          val <- runSandbox' ref $ do
+            start =<< register "sed_regex" "sed" [ "-u", "s/a/b/" ] def { psCapture = Just CaptureStdout }
+            interactWith "sed_regex" "a\n" 1
+          val `shouldBe` "b\n"
+      it "interactive Test : QuickCheck(setup)" $ do
+        val <- runSandbox' gref $ do
+          start =<< register "sed_regex" "sed" [ "-u", "s/a/b/" ] def { psCapture = Just CaptureStdout }
+          interactWith "sed_regex" "a\n" 1
+        val `shouldBe` "b\n"
+      it "interactive Test : QuickCheck(run)" $
+        property $ a2btest gref
+      it "setFile" $ do
+        withSandbox $ \ref -> do
+          let content =
+                  [str|#!/bin/env bash
+                      |while true ; do echo hhh ; sleep 1;done
+                      |]
+          putStr content
+          file <- runSandbox' ref $ setFile "str1" content
+          readFile file `shouldReturn`  content
+      it "set/getVariable" $ do
+        withSandbox $ \ref -> do
+          runSandbox' ref $ do
+            v <- I.isVerbose
+            liftIO $ v `shouldBe` True
+            _ <- setVariable I.verbosityKey False
+            v' <- I.isVerbose
+            liftIO $ v' `shouldBe` False
+          runSandbox' ref I.isVerbose `shouldReturn` False
+          _ <- runSandbox' ref $ setVariable I.verbosityKey True
+          runSandbox' ref I.isVerbose `shouldReturn` True
+#if defined(__MACOSX__) ||  defined(__WIN32__)
+#else
+    describe "signal test" $ do
+      it "send kill signal for process groups" $ do
+        val <- newIORef $ error "do not eval this"
+        withSandbox $ \ref -> runSandbox' ref $ do
+          file <- setFile "str1"
+                  [str|#!/usr/bin/env bash
+                      |trap "echo catch signal" 1 2 3 15
+                      |while true ; do echo hhh ; sleep 1;done
+                      |]
+          liftIO $ setExecuteMode file
+          fil2 <- setFile' "str2"
+                  [("file",file)]
+                  [str|#!/usr/bin/env bash
+                      |trap "echo catch signal" 1 2 3 15
+                      |{{file}}&
+                      |{{file}}&
+                      |{{file}}&
+                      |while true ; do echo hhh ; sleep 1;done
+                      |]
+          liftIO $ setExecuteMode fil2
+          _ <- register "scr1" fil2 [] def
+          startAll
+          liftIO $ writeIORef val ref
+          pids <- I.getAvailablePids
+          liftIO $ threadDelay $ 1 * 1000 * 1000
+          liftIO $ (length pids >= 4) `shouldBe` True
+        ref' <- readIORef val
+        pids <- runSandbox' ref' $ I.getAvailablePids
+        length pids `shouldBe` 0
+
+      it "send kill signal for process groups" $ do
+        sandbox "test" $ do
+          file <- setFile "str1"
+                  [str|#!/usr/bin/env bash
+                      |trap "echo catch signal" 1 2 3 15
+                      |while true ; do echo hhh ; sleep 1;done
+                      |]
+          liftIO $ setExecuteMode file
+          fil2 <- setFile' "str2"
+                  [("file",file)]
+                  [str|#!/usr/bin/env bash
+                      |trap "echo catch signal" 1 2 3 15
+                      |{{file}}&
+                      |{{file}}&
+                      |{{file}}&
+                      |while true ; do echo hhh ; sleep 1;done
+                      |]
+          liftIO $ setExecuteMode fil2
+          _ <- register "scr1" fil2 [] def
+          startAll
+          pids <- I.getAvailablePids
+          liftIO $ (length pids >= 4) `shouldBe` True
+      it "not send kill signal for process groups" $ do
+        val <- newIORef $ error "do not eval this"
+        withSandbox $ \ref -> runSandbox' ref $ do
+          file <- setFile "str1"
+                  [str|#!/usr/bin/env bash
+                      |trap "echo catch signal" 1 2 3 15
+                      |while true ; do echo hhh ; sleep 1;done
+                      |]
+          liftIO $ setExecuteMode file
+          fil2 <- setFile' "str2"
+                  [("file",file)]
+                  [str|#!/usr/bin/env bash
+                      |trap "echo catch signal" 1 2 3 15
+                      |{{file}}&
+                      |{{file}}&
+                      |{{file}}&
+                      |while true ; do echo hhh ; sleep 1;done
+                      |]
+          liftIO $ setExecuteMode fil2
+          _ <- register "scr1" fil2 [] def
+          startAll
+          _ <- setVariable I.cleanUpKey False
+          pids <- I.getAvailablePids
+          liftIO $ writeIORef val ref
+          liftIO $ do
+            (length pids >= 4) `shouldBe` True
+        ref' <- readIORef val
+        pids <- runSandbox' ref' $ I.getAvailablePids
+        (length pids > 0 ) `shouldBe` True
+        pids' <- runSandbox' ref' $ do
+          I.cleanUpProcesses
+          I.getAvailablePids
+        length pids' `shouldBe` 0
+#endif
+
+setFile' :: H.MuVar a
+         => String
+         -> [(String, a)]
+         -> String
+         -> Sandbox FilePath
+setFile' filename keyValues template  = do
+  str' <- H.hastacheStr
+          H.defaultConfig
+          (H.encodeStr template)
+          (H.mkStrContext context')
+  setFile filename $ T.unpack $ TL.toStrict str'
+  where
+    context' str' = (M.fromList (map (\(k,v) -> (k,H.MuVariable v)) keyValues)) M.! str'
+
+setExecuteMode :: FilePath -> IO ()
+setExecuteMode file = do
+  stat <- getFileStatus file
+  setFileMode file (fileMode stat `unionFileModes` ownerExecuteMode)


### PR DESCRIPTION
Add isBindableByProc which uses /proc/net to search available port.
Change userPorts-range from [49152..65535] to [5001..32767].
 ([49152..65535] is os-port-searching area.)
Add cleanUpProcesses which stops process-groups when test is finished.
Add runSB and withSandbox funtions for unit-test
