### PR TITLE
Update test for removing environment dependency

### DIFF
--- a/test-sandbox/ChangeLog.md
+++ b/test-sandbox/ChangeLog.md
@@ -1,3 +1,7 @@
+## 0.1.3.1
+
+* Replace nc with runhaskell
+
 ## 0.1.3
 
 * Fix build failure with directory-1.2.2.0 which exposes findExecutables

--- a/test-sandbox/test-sandbox.cabal
+++ b/test-sandbox/test-sandbox.cabal
@@ -1,5 +1,5 @@
 Name:           test-sandbox
-Version:        0.1.3
+Version:        0.1.3.1
 Cabal-Version:  >= 1.14
 Category:       Testing
 Synopsis:       Sandbox for system tests
@@ -28,7 +28,7 @@ Source-Repository head
 Source-Repository this
     Type:       git
     Location:   https://github.com/gree/haskell-test-sandbox
-    Tag:        test-sandbox_0.1.3
+    Tag:        test-sandbox_0.1.3.1
 
 Library
     Exposed-modules:    Test.Sandbox


### PR DESCRIPTION
This test suite uses nc command for launching server.
On some linux environment, the nc-command is not installed.
This pull request replaces nc-command.
