### PR TITLE
Allow  '.' and '-' for valid procsss name

### DIFF
--- a/test-sandbox/ChangeLog.md
+++ b/test-sandbox/ChangeLog.md
@@ -1,3 +1,7 @@
+## 0.1.4
+
+* Allow '.' and '-' for valid procsss name
+
 ## 0.1.3.1
 
 * Replace nc with runhaskell

--- a/test-sandbox/src/Test/Sandbox/Internals.hs
+++ b/test-sandbox/src/Test/Sandbox/Internals.hs
@@ -196,7 +196,7 @@ isValidProcessName :: String -> Bool
 isValidProcessName s = not (null s)
     && isAlpha (head s)
     && all isAllowed (tail s)
-  where isAllowed c = isAlphaNum c || c == '_'
+  where isAllowed c = isAlphaNum c || ( c `elem` ['_','-','.'] )
 
 getProcess :: String -> Sandbox SandboxedProcess
 getProcess name = do

--- a/test-sandbox/test-sandbox.cabal
+++ b/test-sandbox/test-sandbox.cabal
@@ -1,5 +1,5 @@
 Name:           test-sandbox
-Version:        0.1.3.1
+Version:        0.1.4
 Cabal-Version:  >= 1.14
 Category:       Testing
 Synopsis:       Sandbox for system tests
@@ -28,7 +28,7 @@ Source-Repository head
 Source-Repository this
     Type:       git
     Location:   https://github.com/gree/haskell-test-sandbox
-    Tag:        test-sandbox_0.1.3.1
+    Tag:        test-sandbox_0.1.4
 
 Library
     Exposed-modules:    Test.Sandbox


### PR DESCRIPTION
Currently, when process name includes '-' and '.', sandboxed process can not run,
because valid process name checker does not allow the characters.
For example, process name of fakes3-2 becomes failure.
This patch allows '-' and '.' characters for process name.
 