### PR TITLE
Add a function of changing working-directory and environment-variables

### DIFF
--- a/test-sandbox/ChangeLog.md
+++ b/test-sandbox/ChangeLog.md
@@ -1,3 +1,7 @@
+## 0.1.5
+
+* Add the function of changing environment-variables and working-directory with register-function-arguments.
+
 ## 0.1.4
 
 * Allow '.' and '-' for valid procsss name

--- a/test-sandbox/test-sandbox.cabal
+++ b/test-sandbox/test-sandbox.cabal
@@ -1,5 +1,5 @@
 Name:           test-sandbox
-Version:        0.1.4
+Version:        0.1.5
 Cabal-Version:  >= 1.14
 Category:       Testing
 Synopsis:       Sandbox for system tests
@@ -28,7 +28,7 @@ Source-Repository head
 Source-Repository this
     Type:       git
     Location:   https://github.com/gree/haskell-test-sandbox
-    Tag:        test-sandbox_0.1.4
+    Tag:        test-sandbox_0.1.5
 
 Library
     Exposed-modules:    Test.Sandbox


### PR DESCRIPTION
Currently test-sandbox can not control working-directory and environment-variables  for each process.
To change the directory and variables, register-function and ProcessSettings-data are modified.


