### PR TITLE
Support for HUnit-1.3

### DIFF
--- a/test-sandbox-hunit/ChangeLog.md
+++ b/test-sandbox-hunit/ChangeLog.md
@@ -1,3 +1,7 @@
+## 0.1.2
+
+* Support for HUnit-1.3
+
 ## 0.1.1
 
 * Fix error for ghc710

--- a/test-sandbox-hunit/src/Test/Sandbox/HUnit.hs
+++ b/test-sandbox-hunit/src/Test/Sandbox/HUnit.hs
@@ -1,6 +1,7 @@
 -- author: Benjamin Surma <benjamin.surma@gmail.com>
 
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE CPP #-}
 
 module Test.Sandbox.HUnit (
     assertFailure
@@ -49,4 +50,8 @@ assertException s a =
   assertBool s =<< (a >> return False) `catchError` const (return True)
 
 wrap :: Sandbox () -> Sandbox ()
+#if MIN_VERSION_HUnit(1,3,0)
+wrap action = action `catch` (\ (HUnitFailure _ e :: HUnitFailure) -> throwError e)
+#else
 wrap action = action `catch` (\ (HUnitFailure e :: HUnitFailure) -> throwError e)
+#endif

--- a/test-sandbox-hunit/test-sandbox-hunit.cabal
+++ b/test-sandbox-hunit/test-sandbox-hunit.cabal
@@ -1,5 +1,5 @@
 Name:           test-sandbox-hunit
-Version:        0.1.1
+Version:        0.1.2
 Cabal-Version:  >= 1.14
 Category:       Testing
 Synopsis:       HUnit convenience functions for use with test-sandbox
@@ -21,7 +21,7 @@ Source-Repository head
 Source-Repository this
     Type:       git
     Location:   https://github.com/gree/haskell-test-sandbox
-    Tag:        test-sandbox-hunit_0.1.1
+    Tag:        test-sandbox-hunit_0.1.2
 
 Library
     Exposed-modules:    Test.Sandbox.HUnit


### PR DESCRIPTION
The definition of HUnitFailure is changed for updating HUnit-version.
Add support for both HUnit-1.3 and old one.

