### PR TITLE
Fix property-test not to pass not-ascii-charactors

### DIFF
--- a/test-sandbox/test/test.hs
+++ b/test-sandbox/test/test.hs
@@ -42,7 +42,6 @@ a2btest ref str' = a2btest' ref $ filter (\c -> isAlphaNum c && isAscii c) str'
 a2btest' :: I.SandboxStateRef -> [Char] -> Property
 a2btest' ref str' =
   monadicIO $ do
-    liftIO $ print str'
     v <- liftIO $ runSandbox' ref $ interactWith "sed_regex" (str' ++ "\n") 1
     assert $ v == ((a2b str') ++ "\n")
 

--- a/test-sandbox/test/test.hs
+++ b/test-sandbox/test/test.hs
@@ -37,11 +37,12 @@ a2b ('a':xs) = 'b':xs
 a2b (x:xs) = x:a2b xs
 
 a2btest :: I.SandboxStateRef -> [Char] -> Property
-a2btest ref str' = a2btest' ref $ filter isAlphaNum str'
+a2btest ref str' = a2btest' ref $ filter (\c -> isAlphaNum c && isAscii c) str'
 
 a2btest' :: I.SandboxStateRef -> [Char] -> Property
 a2btest' ref str' =
   monadicIO $ do
+    liftIO $ print str'
     v <- liftIO $ runSandbox' ref $ interactWith "sed_regex" (str' ++ "\n") 1
     assert $ v == ((a2b str') ++ "\n")
 
@@ -126,9 +127,8 @@ main = withSandbox $ \gref -> do
           start =<< register "sed_regex" "sed" [ "-u", "s/a/b/" ] def { psCapture = Just CaptureStdout }
           interactWith "sed_regex" "a\n" 1
         val `shouldBe` "b\n"
---     ToDo: This test fails in local linux. 
---      it "interactive Test : QuickCheck(run)" $
---        property $ a2btest gref
+      it "interactive Test : QuickCheck(run)" $
+        property $ a2btest gref
       it "setFile" $ do
         withSandbox $ \ref -> do
           let content =


### PR DESCRIPTION
`isAlphaNum`-functions of base-package passes not ascii-characters, and `interactWith`-function of test-sandbox package can not handle the characters correctly.
So this pr replaces `isAlphaNum` with `isAlphaNum && isAscii`.